### PR TITLE
Add dependencies to opam file

### DIFF
--- a/smtlib.opam
+++ b/smtlib.opam
@@ -8,6 +8,8 @@ dev-repo: "https://github.com/rvantonder/smtlib.git"
 license: "Apache-2.0"
 build: [["jbuilder" "build" "-p" name "-j" jobs "@install"]]
 depends: [
+  "core"
+  "menhir"
   "ppx_jane"
   "ppx_deriving"
 ]


### PR DESCRIPTION
"core" and "menhir" were missing from the opam file